### PR TITLE
[Fix]  __identifier, _initialValues fix 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,7 @@ export default class Form {
   public reset() {
     this.keys.forEach(key => {
       Object.assign(this, {
-        [key]: this._initialValues[key]
+        [key]: this.initialValues[key]
       });
 
       this.setTouched(key, false);

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export default class Form {
 
   private _errors: Record<string, string | undefined> = {};
 
-  private __identifier: string;
+  private readonly __identifier: string;
 
   private readonly keys: string[];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,7 @@ export default class Form {
   public reset() {
     this.keys.forEach(key => {
       Object.assign(this, {
-        [key]: this.initialValues[key]
+        [key]: this._initialValues[key]
       });
 
       this.setTouched(key, false);


### PR DESCRIPTION
안녕하세요. 두가지 정도 수정하면 어떨까 싶어서 남겨봅니다. 

1. _initialValues -> initialValues 수정
-  `reset()` 에서 가져오는 초기값을 `_initialValues`가 아닌 `get initialValues` 로 수정하면 어떨까 싶습니다. 기존 코드처럼으로도 참조할 수 있지만, `private` 한 값인데 `get initialValues`로 가지고 와야 의미가 맞지 않나 싶어서요. 

2. __identifier에 readonly 식별자 추가
- `__identifier` 도 `constructor`에서 선언 이후로 수정이 되지 않는데, `readonly`를 안붙일 이유가 없다고 봅니다.  혹시나 다른 의도가 있으신건지 궁금합니다. ㅎㅎ
